### PR TITLE
Added -mfp32 option in "termio" example Makefile

### DIFF
--- a/examples/termio/Makefile-templ
+++ b/examples/termio/Makefile-templ
@@ -19,7 +19,7 @@ UMPS2_INCLUDE_DIR = $(UMPS2_DIR_PREFIX)/include/umps2
 
 # Compiler options
 CFLAGS_LANG = -ffreestanding -ansi
-CFLAGS_MIPS = -mips1 -mabi=32 -mno-gpopt -G 0 -mno-abicalls -fno-pic
+CFLAGS_MIPS = -mips1 -mabi=32 -mno-gpopt -G 0 -mno-abicalls -fno-pic -mfp32
 CFLAGS = $(CFLAGS_LANG) $(CFLAGS_MIPS) -I$(UMPS2_INCLUDE_DIR) -Wall -O0
 
 # Linker options


### PR DESCRIPTION
Specify -mfp32 (32-bit FP regs) option in "termio" example Makefile, as it's required for mips1 targets.