### PR TITLE
Fixed a dangling pointer in netblockq::dequeue

### DIFF
--- a/src/umps/vde_network.cc
+++ b/src/umps/vde_network.cc
@@ -320,6 +320,7 @@ int netblockq::dequeue(char *pcontent, int len)
 		class netblock *oldhead=head;
 		int packlen;
 		head=oldhead->getNext();
+		if (head == NULL) tail = NULL;
 		packlen=oldhead->getLen();
 		if (len < packlen) packlen=len;
 		memcpy(pcontent,oldhead->getContent(),packlen);


### PR DESCRIPTION
That problem was causing a crash when netblockq::enqueue was invoked immediately after a netblockq::dequeue invoked when there was only a packet in the queue